### PR TITLE
Update ships_methods.R (bug fix: interpolate.ais.data())

### DIFF
--- a/R/ships_methods.R
+++ b/R/ships_methods.R
@@ -108,6 +108,9 @@ interpolate.ais.data <- function (aisdata)
       new.t.first <- format(as.POSIXct(t.first, tz = "UTC") + secs.to.add)
     }
     t.last <- aisdata.one.id[nrow(aisdata.one.id), "time"]
+    if (nchar(t.last) == 10) {
+      t.first <- paste(t.last, "00:00:00", sep = " ")
+    }
     mins <- as.numeric(substr(t.last, nchar(t.last) - 4,
                               nchar(t.last) - 3))
     new.mins <- ifelse(mins < 30, "00", "30")


### PR DESCRIPTION
Function:
interpolate.ais.data()

Bug:
An intermediate date/time value (t.last) could produce a malformed time if source time was provided in “cropped” format (HH:MM:SS) omitted, implying 00:00:00)

Cause:
Missing test & fix for presence of “00:00:00” part of string

Fix:
Added:

if (nchar(t.last) == 10) {
  	t.last <- paste(t.last, "00:00:00", sep = " ")
}

This is equivalent to handling of t.first; prob. omitted by accident