### PR TITLE
Update raster-methods.R (fixes to as.raster and as.DeponsRaster)

### DIFF
--- a/R/raster-methods.R
+++ b/R/raster-methods.R
@@ -385,7 +385,7 @@ setGeneric("as.DeponsRaster", function(x){})
 
 #' @title Convert a RasterLayer into a DeponsRaster
 #' @name as.DeponsRaster
-#' @aliases as.DeponsRaster, RasterLayer-method
+#' @aliases as.DeponsRaster,RasterLayer-method
 #' @description Converts a \code{\link[raster:Raster-class]{RasterLayer}} into a \code{DeponsRaster}.
 #' @details Maintains CRS (if defined) and value of NA cells. Currently DEPONS requires a fixed
 #' cell size of 400 x 400 m, and cell size is set to this value.
@@ -394,8 +394,8 @@ setGeneric("as.DeponsRaster", function(x){})
 #' @seealso \code{\link{raster}} for converting a DeponsRaster into a RasterLayer
 #' @examples
 #' data(bathymetry)
-#' bathymetry_RasterLayer <- as.DeponsRaster(bathymetry)
-#' bathymetry <- raster::raster(bathymetry_RasterLayer)
+#' bathymetry_RasterLayer <- as.raster(bathymetry)
+#' bathymetry <- as.DepoonsRaster(bathymetry_RasterLayer)
 #' @exportMethod as.DeponsRaster
 setMethod("as.DeponsRaster", signature("RasterLayer"),
           function(x) {
@@ -418,7 +418,7 @@ setGeneric("as.raster", function(x, ...){})
 
 #' @title Convert a DeponsRaster into a RasterLayer
 #' @name as.raster
-#' @aliases as.raster, DeponsRaster-method
+#' @aliases as.raster,DeponsRaster-method
 #' @description Converts a \code{DeponsRaster} into a \code{\link[raster:Raster-class]{RasterLayer}} for easier manipulation with common R tools.
 #' @details Maintains cell size / resolution, CRS (if defined) and value of NA cells.
 #' @param x A \code{DeponsRaster}


### PR DESCRIPTION
Fixed: switched two lines in example of as.DeponsRaster (-> removed 2 errors); inserted 2 spaces into @alias lines (-> removed 2 warnings).

All checks nicely now :)