### PR TITLE
Update ships_methods.R (small update to check.DeponsShips)

### DIFF
--- a/R/ships_methods.R
+++ b/R/ships_methods.R
@@ -292,10 +292,10 @@ check.DeponsShips <- function(x, threshold = 35, fix = F, replacements = NA, lan
   # if calibration landscape provided, round positions on border up/down to map extent
   if (!is.null(landscape)) {
     for (i in 1:length(x@ships$name)) {
-      x@routes$route[[i]]$x[x@routes$route[[i]]$x < as.numeric(landscape@ext[1])] <- as.numeric(landscape@ext[1])
-      x@routes$route[[i]]$x[x@routes$route[[i]]$x > as.numeric(landscape@ext[3])] <- as.numeric(landscape@ext[3])
-      x@routes$route[[i]]$y[x@routes$route[[i]]$y < as.numeric(landscape@ext[2])] <- as.numeric(landscape@ext[2])
-      x@routes$route[[i]]$y[x@routes$route[[i]]$y > as.numeric(landscape@ext[4])] <- as.numeric(landscape@ext[4])
+      x@routes$route[[i]]$x[x@routes$route[[i]]$x < as.numeric(landscape@ext[1])] <- as.numeric(landscape@ext[1]) + 1
+      x@routes$route[[i]]$x[x@routes$route[[i]]$x > as.numeric(landscape@ext[3])] <- as.numeric(landscape@ext[3]) - 1
+      x@routes$route[[i]]$y[x@routes$route[[i]]$y < as.numeric(landscape@ext[2])] <- as.numeric(landscape@ext[2]) + 1
+      x@routes$route[[i]]$y[x@routes$route[[i]]$y > as.numeric(landscape@ext[4])] <- as.numeric(landscape@ext[4]) - 1
     }
   }
   return(x)


### PR DESCRIPTION
added an extra safety buffer of 1 meter to the position adjustment made by check.DeponsShips with 'fix=T', as ships placed exactly on the map boundary sometimes (but not always - search me) cause DEPONS to complain