### PR TITLE
Update raster-methods.R

### DIFF
--- a/R/raster-methods.R
+++ b/R/raster-methods.R
@@ -391,7 +391,7 @@ setGeneric("as.DeponsRaster", function(x){})
 #' cell size of 400 x 400 m, and cell size is set to this value.
 #' @param x A \code{RasterLayer}
 #' @return A \code{DeponsRaster}
-#' @seealso \code{\link{raster::raster}} for converting a DeponsRaster into a RasterLayer
+#' @seealso \code{\link{as.raster}} for converting a DeponsRaster into a RasterLayer
 #' @examples
 #' data(bathymetry)
 #' bathymetry_RasterLayer <- as.raster(bathymetry)
@@ -450,8 +450,8 @@ setMethod("as.raster", signature("DeponsRaster"),
 #'@details
 #'The complete series of maps, consisting of existing and missing maps, is arranged as a chronological stack. For each raster cell
 #'in the stack, the prediction function is fit to the existing values, and the missing values are predicted from the function.
-#'The fitted function is of the form ‘α * sine(x) + β * cosine(x)’, where α & β are estimated using a basic linear model. This is equivalent
-#'to ‘Amplitude * sine(x + Phase)’, but is more straightforward to estimate. The resulting curve satisfies the assumption that
+#'The fitted function is of the form ‘\eqn{\alpha} * sine(x) + \eqn{\beta} * cosine(x)’, where \eqn{\alpha} & \eqn{\beta} are estimated using a basic linear model. 
+#'This is equivalent to ‘Amplitude * sine(x + Phase)’, but is more straightforward to estimate. The resulting curve satisfies the assumption that
 #'the data described in the map series should have a single series maximum and minimum, and should loop around seamlessly at end of series.
 #'
 #'The function requires at least 3 existing maps in the series to interpolate from. Number of total entries and missing entries is arbitrary.


### PR DESCRIPTION
- fixed one wrong link (pointed to raster::raster but was intended as DEPONS2R::as.raster) (this was a note in the previous check - resolved)
- replaced alpha/beta symbols with markdown versions \eqn{\alpha} and \eqn{\beta}